### PR TITLE
Eclipse patches to improve L&F of Eclipse 4.7.x with GTK 3.22

### DIFF
--- a/gtk-3.0/eclipse-patches/application-patches.css
+++ b/gtk-3.0/eclipse-patches/application-patches.css
@@ -1,0 +1,49 @@
+/*
+ * Patches for GTK3 and Eclipse 4.7.
+ *
+ * This file is added directly after the application specific css of Eclipse.
+ * Here we override settings used by Eclipse which we don't want.
+ *
+ * This file is passed as a VM argument to Eclipse, with
+ * -Dorg.eclipse.swt.internal.gtk.cssFile=/usr/share/themes/Clearlooks-Phenix/gtk-3.0/eclipse-patches/application-patches.css
+ */
+
+
+
+/*
+ * Eclipse css sets the minimum height of text fields to 26px,
+ * to make the Adwaita theme less spacious in Eclipse.
+ *
+ * We overwrite this here.
+ *
+ * See org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swtgtk_320.css
+ *
+ * See JEP-665.
+ */
+entry {
+    min-height: 12px;
+}
+
+/*
+ * Ensure toolbars, and also by extension part stack tabs, have some minimal height.
+ *
+ * See JEP-401, JEP-678.
+ */
+toolbar {
+    min-height: 23px;
+}
+
+/*
+ * Give some padding to toolbars and toolbar buttons,
+ * so that toolbar buttons don't appear cramped by their borders.
+ * 
+ * See JEP-401.
+ */
+toolbar {
+	padding-top: 2px;
+	padding-bottom: 2px;
+}
+
+toolbar toolbutton button {
+	padding: 1px;
+}

--- a/gtk-3.0/eclipse-patches/theme-patches.css
+++ b/gtk-3.0/eclipse-patches/theme-patches.css
@@ -1,0 +1,264 @@
+/*
+ * Eclipse related patches for the theme.
+ *
+ * Everything that we can patch from the theme should be patched here,
+ * instead of at the application level. This way we also ensure the look-and-feel
+ * of Eclipse applications which are not instructed to use "application-patches.css".
+ */
+
+/*
+ * Eclipse css sets the padding of toolbar buttons to 0, resulting in a cramped toolbar.
+ * We prevent this with a min-width.
+ *
+ * See org.eclipse.swt/Eclipse SWT PI/gtk/org/eclipse/swt/internal/gtk/swtgtk_320.css
+ */
+toolbar toolbutton button {
+    min-width: 20px;
+}
+
+/*
+ * Prevent progress bars from clipping their progress bar area,
+ * since a wrong size hint is computed during the call:
+ *
+ * org.eclipse.jface.dialogs.ProgressMonitorDialog.createDialogArea(Composite)
+ *
+ * The hint is too small for the Clearlooks-Phenix theme for GTK 3.22,
+ * which sets minimum height for progress bars to 9px.
+ *
+ * See JEP-668.
+ */
+
+progressbar.horizontal trough,
+progressbar.horizontal progress {
+	min-height: 9px;
+}
+
+progressbar.horizontal progress,
+row progressbar progress,
+row:hover progressbar progress,
+row:selected progressbar progress,
+row:selected:focus progressbar progress {
+	min-height: 9px;
+}
+
+/**
+ * Remove extra padding added to cells in tables.
+ *
+ * See JEP-552 and JEP-504.
+ */
+.cell {
+	padding: 1px;
+}
+
+/*
+ * Add extra spacing around radio buttons and check boxes.
+ *
+ * See JEP-665.
+ */
+
+check, radio {
+  margin: 0 2px;
+}
+
+/*
+ * Border of tab folders overlap with borders of entities in the tabs.
+ *
+ * See JEP-665.
+ */
+
+notebook.frame {
+    border: none;
+}
+
+/*
+ * Without the border of the tab folder (removed above),
+ * the left-most tab does not have a left border due to a negative left margin.
+ *
+ * We set the margin to 0 to prevent this.
+ */
+notebook header.top tab {
+	margin-left: 0;
+}
+
+notebook viewport {
+	background-color: @theme_bg_color;
+}
+
+notebook tab {
+	border-color: @border_color;
+	background-color: transparent;
+}
+
+notebook tab * {
+	background-color: transparent;
+}
+
+/*
+ * Border of groups overlap with borders of entities in the group.
+ *
+ * See JEP-665.
+ */
+
+scrolledwindow frame {
+	border: none;
+}
+
+/*
+ * Fix for tab height.
+ *
+ * See JEP-665.
+ */
+notebook box label {
+    padding-bottom: 2px;
+    padding-top: 2px;
+}
+
+
+/*
+ * Inline color definitions for tooltip background and foreground colors,
+ * since SWT is not able to parse the referenced colors definitions from "gtk.css".
+ *
+ * See JEP-662.
+ */
+tooltip,
+tooltip.background,
+.tooltip,
+.tooltip.background {
+	background-color: #fcfcfc;
+	color: #000000;
+}
+
+/*
+ * Reduce padding in spin buttons, so that they aren't huge.
+ *
+ * See JEP-677.
+ */
+spinbutton button {
+    padding: 2px 5px;
+}
+
+
+/*
+ * Reduce padding between menu items, so that menus don't take so much space.
+ *
+ * See JEP-674.
+ */
+menu menuitem,
+.menu menuitem {
+	padding: 3px 4px;
+}
+
+/*
+ * Put the outline further inside widgets, to avoid selected buttons
+ * which look cut off at the bottom.
+ *
+ * In GTK 3.22, the offset-outline for the bottom side is one pixel lower
+ * than it should be.
+ *
+ * With 2px offset, it coincides with the bottom border of e.g. selected buttons,
+ * making the other parts of the border thicker in comparison.
+ *
+ * See JEP-670.
+ */
+* {
+	outline-offset: -3px;
+}
+
+/*
+ * Reduce the size of combo boxes.
+ *
+ * See JEP-675.
+ */
+combobox entry.combo,
+combobox button.combo {
+	padding: 4px;
+}
+
+/*
+ * Prevent borders from being drawn for labels.
+ *
+ * See JEP-679.
+ */
+entry.flat {
+    border: none;
+}
+
+/*
+ * Remove border from horizontal scrollbar, to be consistent with vertical scrollbar.
+ *
+ * See JEP-687.
+ */
+scrollbar.horizontal {
+    border-width: 0px;
+}
+
+/*
+ * We don't want focused buttons to have a different background than normally.
+ *
+ * See JEP-400.
+ */
+button:focus {
+	background-image: -gtk-gradient (linear,
+	                  left top,
+	                  left bottom,
+	                  from (@button_gradient_a),
+	                  color-stop (0.50, @button_gradient_b),
+	                  color-stop (0.50, @button_gradient_c),
+	                  to (@button_gradient_d));
+	background-color: transparent;
+}
+
+/*
+ * Don't draw a border at the junction node where scroll bars meet.
+ *
+ * See JEP-688.
+ */
+scrolledwindow junction.frame {
+	border: none;
+}
+
+
+/*
+ * Hide toolbar button selection border for focused buttons. 
+ *
+ * See CR-119015.
+ */
+/* hide border for clicked toolbar buttons */
+toolbar toolbutton button.flat:focus {
+    border-image: none;
+}
+
+/* but show the border if on hover or if toggled */
+toolbar toolbutton button.flat:hover,
+toolbar toolbutton button.flat:checked {
+	border-radius: 3px;
+	border-width: 1px 1px 2px 1px;
+	border-style: solid;
+	border-color: transparent;
+}
+
+toolbar toolbutton button.flat:hover {
+	border-image: url("../img/border-focused.svg") 3 3 4 3 / 3px 3px 4px 3px repeat;
+}
+
+toolbar toolbutton button.flat:checked {
+	border-image: url("../img/border-inline-button.svg") 3 3 4 3 / 3px 3px 4px 3px repeat;
+}
+
+/*
+ * Fix button alignment and padding in file open dialogs,
+ *
+ * See JEP-123, and commit c03d0c26165a07580619605459db474dbfa64bd1. 
+ */
+button {
+	padding: 3px 4px 3px 4px;
+}
+
+/*
+ * Grey-out Eclipse toolbar icons when disabled.
+ *
+ * See CR-119055.
+ */
+*:disabled {
+	-gtk-icon-effect: dim;
+}

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -23,7 +23,7 @@
 
 	-gtk-outline-radius: 2px;
 	-gtk-icon-style: regular; /* disable symbolic icons */
-	
+
 	-GtkWindow-resize-grip-width: 11;
 	-GtkWindow-resize-grip-height: 11;
 }
@@ -2046,9 +2046,9 @@ treeview {
 
 view,
 view:selected,
-view:selected:focus, 
+view:selected:focus,
 .view:selected,
-.view:selected:focus, 
+.view:selected:focus,
 view text selection,
 .view text selection,
 view text selection:focus,

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -1197,9 +1197,9 @@ combobox > .linked > button.combo:hover:last-child,
 combobox > .linked > button.combo:checked:last-child,
 combobox > .linked > button.combo:focus:hover:last-child,
 combobox > .linked > button.combo:disabled:last-child {
-	border-image-width: 3px 3px 4px 0;
-	border-radius: 0 3px 3px 0;
-	border-width: 0 1;
+	border-image-width: 3px 3px 4px 0px;
+	border-radius: 0px 3px 3px 0px;
+	border-width: 0px 1px;
 }
 combobox > .linked > entry.combo:only-child,
 combobox > .linked > button.combo:only-child,

--- a/gtk-3.0/gtk.css
+++ b/gtk-3.0/gtk.css
@@ -14,7 +14,7 @@
 @define-color theme_selected_bg_color #86abd9;
 @define-color theme_selected_fg_color #ffffff;
 
-@define-color theme_tooltip_bg_color #f5f5b5;
+@define-color theme_tooltip_bg_color #fcfcfc;
 @define-color theme_tooltip_fg_color #000000;
 
 @define-color theme_text_color #1a1a1a;
@@ -312,25 +312,25 @@
 
 /* slider */
 
-@define-color scrollbar_slider_bg_color shade(@core_color_b, 0.99);
+@define-color scrollbar_slider_bg_color shade(@theme_base_color, 1.20); 
 
 @define-color scrollbar_slider_gradient_a @scrollbar_slider_bg_color;
-@define-color scrollbar_slider_gradient_b shade(@core_color_b, 0.96);
-@define-color scrollbar_slider_gradient_c shade(@core_color_b, 0.92);
-@define-color scrollbar_slider_gradient_d shade(@core_color_b, 0.88);
+@define-color scrollbar_slider_gradient_b shade(@theme_base_color, 0.96);
+@define-color scrollbar_slider_gradient_c shade(@theme_base_color, 0.92);
+@define-color scrollbar_slider_gradient_d shade(@theme_base_color, 0.88);
 
-@define-color scrollbar_slider_border_color mix(#000000, shade(@core_color_b, 0.72), 0.95);
+@define-color scrollbar_slider_border_color mix(#000000, shade(@theme_base_color, 0.72), 0.95);
 
-@define-color scrollbar_slider_inner_border_color shade(@core_color_b, 1.04);
+@define-color scrollbar_slider_inner_border_color shade(@theme_base_color, 1.04);
 
 /* slider hover */
 
-@define-color scrollbar_slider_hover_bg_color shade(@core_color_a, 1.03);
+@define-color scrollbar_slider_hover_bg_color shade(@core_color_a, 0.99);
 
 @define-color scrollbar_slider_hover_gradient_a @scrollbar_slider_hover_bg_color;
-@define-color scrollbar_slider_hover_gradient_b shade(@core_color_a, 0.99);
-@define-color scrollbar_slider_hover_gradient_c shade(@core_color_a, 0.96);
-@define-color scrollbar_slider_hover_gradient_d shade(@core_color_a, 0.91);
+@define-color scrollbar_slider_hover_gradient_b shade(@core_color_a, 0.96);
+@define-color scrollbar_slider_hover_gradient_c shade(@core_color_a, 0.92);
+@define-color scrollbar_slider_hover_gradient_d shade(@core_color_a, 0.88);
 
 /* button */
 
@@ -431,6 +431,21 @@
  * imports *
  ***********/
 
+/*
+ * In Eclipse 4.7.x, the css parsing done in SWT will read the .css top-down.
+ * In some cases, such as background color of tooltips, it will stop on the first occurrence it discovers.
+ * So we include the patches once here and once after the actual theme .css,
+ * to ensure SWT doesn't "miss" patched values. 
+ *
+ * See JEP-662.
+ */
+@import url("eclipse-patches/theme-patches.css");
+
 @import url("gtk-widgets-img.css");
 @import url("gtk-widgets.css");
 @import url("applications.css");
+
+/*
+ * Patches related to Eclipse apply after the theme styling.
+ */
+@import url("eclipse-patches/theme-patches.css");

--- a/gtk-3.0/settings.ini
+++ b/gtk-3.0/settings.ini
@@ -1,5 +1,8 @@
 [Settings]
-gtk-color-scheme = "base_color:#ffffff\nbg_color:#edeceb\nfg_color:#000000\nselected_bg_color:#86abd9\nselected_fg_color:#ffffff\ntooltip_bg_color:#f5f5b5\ntooltip_fg_color:#000000\ntext_color:#1a1a1a\nlink_color:#0000ee\nvisited_link_color:#551a8b"
 gtk-auto-mnemonics = 0
 gtk-visible-focus = automatic
 gtk-primary-button-warps-slider = false
+
+gtk-alternative-button-order = true
+#gtk-button-images = 0
+#gtk-menu-images = 0


### PR DESCRIPTION
A number of theme and application styling patches, that aim to restore the look & feel of Eclipse 4.7.x on RHEL 7.2 (GTK 3.14), while working on RHEL 7.4 (GTK 3.22).

The patches are located in `gtk-3.0/eclipse-patches/`, and are done on a separate branch, named `eclipse-patches`.

Most of the patches (ones that are not Eclipse specific) should eventually land on the `master` branch, as a proper part of the theme. From there, they can be PRed to the original `clearlooks-phenix` repository.