### PR TITLE
Fix missing toolbar separators and missing progress bar upper border in Eclipse

### DIFF
--- a/gtk-3.0/eclipse-patches/theme-patches.css
+++ b/gtk-3.0/eclipse-patches/theme-patches.css
@@ -30,7 +30,7 @@ toolbar toolbutton button {
 
 progressbar.horizontal trough,
 progressbar.horizontal progress {
-	min-height: 9px;
+	min-height: 8px;
 }
 
 progressbar.horizontal progress,

--- a/gtk-3.0/eclipse-patches/theme-patches.css
+++ b/gtk-3.0/eclipse-patches/theme-patches.css
@@ -262,3 +262,14 @@ button {
 *:disabled {
 	-gtk-icon-effect: dim;
 }
+
+/*
+ * Fix missing toolbar separators.
+ *
+ * See JEP-896.
+ */
+separator {
+  background: shade(@border_color, 1.30);
+  min-width: 1px;
+  min-height: 1px;
+}


### PR DESCRIPTION
Eclipse patches for JEP-825 and JEP-896.